### PR TITLE
Add imageInline into default elements

### DIFF
--- a/src/ImageRemoveEvent.js
+++ b/src/ImageRemoveEvent.js
@@ -20,6 +20,7 @@ export default class ImageRemoveEvent {
             'image',
             'imageBlock',
             'inlineImage',
+            'imageInline',
         ]
 
         let elementTypes = [


### PR DESCRIPTION
I think the default is always imageInline instead of inlineImage, but maybe there are cases that require inlineImage